### PR TITLE
Update Flutter Version & Fix Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,6 @@ RUN apt-get update && apt-get -y -q --no-install-recommends install \
 RUN apt-get update && apt-get install -y -q --no-install-recommends autoconf automake libtool cmake autoconf-archive \
   build-essential mlton libicu-dev
 
-# Libraries needed by VSCode.
-ADD https://aka.ms/vsls-linux-prereq-script /opt
-RUN chmod 700 vsls-linux-prereq-script && \
-  ./vsls-linux-prereq-script && \
-  rm vsls-linux-prereq-script
-
 # Python3 -- BUG, getting python3.6 and python3.8, causing problems
 RUN apt-get update && apt-get -y install -q --no-install-recommends \
   python3.8 python3.8-distutils python3-pip python3-venv python3.8-dev 
@@ -97,15 +91,6 @@ RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && \
 #RUN /root/.local/bin/leanproject get-mathlib-cache
 #RUN /root/.local/bin/leanproject build
 # RUN /root/.local/bin/leanproject import-graph project_structure.dot
-
-# Install libraries needed by VSCode  
-# - support joining sessions using a browser link 
-WORKDIR /opt 
-RUN wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && chmod +x ~/vsls-reqs && ~/vsls-reqs
-ADD https://aka.ms/vsls-linux-prereq-script /opt
-RUN chmod 700 vsls-linux-prereq-script && \
-  ./vsls-linux-prereq-script && \
-  rm vsls-linux-prereq-script
 
 # Install TypeDB.
 RUN add-apt-repository 'deb [ arch=all ] https://repo.vaticle.com/repository/apt/ trusty main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN python3 -m pipx ensurepath --force
 RUN . ~/.profile
 
 # Flutter and Dart.
-ARG FLUTTER_VERSION=3.0.0
+ARG FLUTTER_VERSION=3.10.5
 ADD https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz /opt
 RUN tar xJvf flutter_linux_${FLUTTER_VERSION}-stable.tar.xz && \
   rm flutter_linux_${FLUTTER_VERSION}-stable.tar.xz


### PR DESCRIPTION
* Updates flutter to v3.10.5 from v3.0.0
* Remove vsls-linux-prereq-script since that appears not to be needed for VS Code liveshare and the link used now 404s causing docker builds to break
  * Didn't test liveshare itself, but seems to install just fine and the script is no longer mentioned in any of the setup documentation

