### PR TITLE
Minor: Set SHELL environment variable to bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8  
 ENV PYTHONIOENCODING utf-8
+ENV SHELL /bin/bash
 
 SHELL ["/bin/bash", "-c"]
 USER 0


### PR DESCRIPTION
This makes it so that VSCode and other tools will use `/bin/bash` in place of `/bin/sh`

Tested a build and it seems to work correctly with VSCode launching `/bin/bash` by default and the environment variable being set

Done in place of https://github.com/kevinsullivan/concepts_exploration/pull/29